### PR TITLE
chore(filename): simplify rawdata file name for consistent chaining

### DIFF
--- a/dfs_solver.py
+++ b/dfs_solver.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from datetime import datetime
+from pathlib import Path
 import pandas as pd
 import os, pulp, sys
 
@@ -101,6 +102,9 @@ def write_results_to_json(results, format):
 def main():
     # At the moment, default to Yahoo and opt-in to OwnersBox by using args
     format = 'yahoo'
+    if len(sys.argv) == 2:
+        if Path(sys.argv[1]).stem == 'ownersbox':
+            format = 'ownersbox'
     if len(sys.argv) == 3: 
         if sys.argv[2] == '--ownersbox' or sys.argv[2] == '-o':
             format = 'ownersbox'

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -22,7 +22,7 @@ def fetch_yahoo_data():
 def write_data(data, format):
     if not os.path.exists('./rawdata'):
         os.makedirs('./rawdata')
-    data.to_csv('./rawdata/' + format + '-' + datetime.now().strftime("%d-%m-%Y-%Hh%Mm%Ss") + '.csv', encoding='utf-8', index=True)
+    data.to_csv('./rawdata/' + format + '.csv', encoding='utf-8', index=True)
 
 # Fetch all positional data from FP, return a DataFrame containing all the data for the week
 def fetch_fp_data():
@@ -111,9 +111,8 @@ def setup_yahoo_df():
 
     df = pd.DataFrame(text['players']['result'])
     df = df[df.gameStartTime.str.startswith('Sun')]
-    df.drop(['sport', 'playerCode', 'gameCode', 'homeTeam', 'awayTeam', 'gameStartTime'], axis=1, inplace=True)
+    df.drop(['sport', 'playerCode', 'gameCode', 'homeTeam', 'awayTeam', 'gameStartTime', 'fppg'], axis=1, inplace=True)
     df['name'] = df['name'].str.strip()
-    df.rename(columns = {'fppg':'yahoo'}, inplace=True)
     df.sort_values(by=['salary'], ascending=False, inplace=True)
     return df
 


### PR DESCRIPTION
It was nice to have multiple rawdata files so I could keep track of points/salaries from earlier in the week ..

but it got a bit more cumbersome when chaining commands. It's easy to do:
`python fetch_data.py --ownersbox && python dfs_solver rawdata/ownersbox.csv` instead of having to run the fetcher and then wait for the data to populate to get the new filename. 